### PR TITLE
Avoid class cast exception

### DIFF
--- a/src/main/java/org/codehaus/mojo/properties/YamlToPropertiesConverter.java
+++ b/src/main/java/org/codehaus/mojo/properties/YamlToPropertiesConverter.java
@@ -51,7 +51,7 @@ class YamlToPropertiesConverter {
 
         final Map<String, String> propertiesMap = new LinkedHashMap<String, String>();
         for (final Map.Entry<String, Object> entry : flattenedMap.entrySet()) {
-            propertiesMap.put(entry.getKey(), (String) entry.getValue());
+            propertiesMap.put(entry.getKey(), String.valueOf(entry.getValue()));
         }
 
         return propertiesMap;


### PR DESCRIPTION
When we define in yaml file for example
valueInt : 5
valueBool : true
we are getting cast excpetion Type(Intgere, Boolean) -> String. Propose to chaneg file to avoid it.
